### PR TITLE
Client build fix

### DIFF
--- a/Assets/Scripts/BuildController.cs
+++ b/Assets/Scripts/BuildController.cs
@@ -3,8 +3,6 @@ using UnityEngine;
 using TMPro;
 using UnityEngine.InputSystem;
 using System;
-using UnityEngine.Tilemaps;
-using UnityEngine.UIElements;
 
 public class BuildController : NetworkBehaviour
 { 

--- a/Assets/Scripts/BuildController.cs
+++ b/Assets/Scripts/BuildController.cs
@@ -1,9 +1,10 @@
 using Mirror;
-using System.Collections;
 using UnityEngine;
 using TMPro;
 using UnityEngine.InputSystem;
 using System;
+using UnityEngine.Tilemaps;
+using UnityEngine.UIElements;
 
 public class BuildController : NetworkBehaviour
 { 
@@ -238,13 +239,14 @@ public class BuildController : NetworkBehaviour
     [Client]
     void ModifyBlock(int x, int y, bool destroy = false)
     {
+        Vector3Int pos = new Vector3Int(x, y, 0);
         if (destroy)
         {
-            CmdRequestDestroyTile(new Vector3Int(x, y, 0));
+            CmdRequestDestroyTile(pos);
         }
-        else
+        else if (GameMapManager.Instance.OnClientIsValidBuildPosition(pos))
         {
-            CmdRequestPlaceTile(new Vector3Int(x, y, 0), TileType.Breakable);
+            CmdRequestPlaceTile(pos, TileType.Breakable);
         }
     }
 

--- a/Assets/Scripts/GameMapManager.cs
+++ b/Assets/Scripts/GameMapManager.cs
@@ -3,8 +3,6 @@ using UnityEngine.Tilemaps;
 using System.Collections.Generic;
 using Mirror;
 using Unity.Mathematics;
-using System;
-using UnityEngine.UIElements;
 
 
 public enum TileType : int

--- a/Assets/Scripts/GameMapManager.cs
+++ b/Assets/Scripts/GameMapManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Mirror;
 using Unity.Mathematics;
 using System;
+using UnityEngine.UIElements;
 
 
 public enum TileType : int
@@ -155,5 +156,11 @@ public class GameMapManager : NetworkBehaviour
         return !isOccupied;
     }
 
-    
+    [Client]
+    public bool OnClientIsValidBuildPosition(Vector3Int position)
+    {
+        int layerMask = LayerMask.GetMask("Player");
+        bool isOccupied = Physics2D.OverlapBox(tilemap.GetCellCenterWorld(position), tileSize, 0f, layerMask);
+        return !isOccupied;
+    }
 }


### PR DESCRIPTION
Dodałem kolejnego checka, który sprawia, że nie można już stawiać na sobie klocków. Z jakiegoś powodu mam teraz ~10 mniej FPS, nawet kiedy nie buduję, mimo, że kod, który dopisałem powinen sie wywoływać tylko podczas budowania klocków. Może to przypadek...